### PR TITLE
Add the jcenter plugin repository to get dokka working. fixes #1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,14 @@
         <latest.jolt.version>0.1.1</latest.jolt.version>
     </properties>
 
+    <pluginRepositories>
+        <pluginRepository>
+            <id>jcenter</id>
+            <name>JCenter</name>
+            <url>https://jcenter.bintray.com/</url>
+        </pluginRepository>
+    </pluginRepositories>
+
     <profiles>
         <profile>
             <id>default</id>
@@ -529,7 +537,7 @@
             <plugin>
                 <groupId>org.jetbrains.dokka</groupId>
                 <artifactId>dokka-maven-plugin</artifactId>
-                <version>0.9.15</version>
+                <version>0.9.17</version>
                 <executions>
                     <execution>
                         <phase>prepare-package</phase>


### PR DESCRIPTION
Also update the version of the plugin as the 0.9.15 does not run on machines with java 9.