### PR TITLE
9 allow configuration of property file names

### DIFF
--- a/src/main/kotlin/com/tyro/oss/rabbit_amazon_bridge/config/MainConfig.kt
+++ b/src/main/kotlin/com/tyro/oss/rabbit_amazon_bridge/config/MainConfig.kt
@@ -31,7 +31,7 @@ import org.springframework.jmx.support.RegistrationPolicy
 @Import(TaskSchedulerConfig::class, RestConfig::class, RabbitEndPointConfigurer::class, SQSPollersConfigurer::class)
 @ComponentScan(value = ["com.tyro.oss.rabbit_amazon_bridge"], excludeFilters = [ComponentScan.Filter(Configuration::class)])
 @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
-@PropertySource(value = ["classpath:private.properties"], ignoreResourceNotFound = true)
+@PropertySource(value = ["\${extra.properties.file}"], ignoreResourceNotFound = true)
 class MainConfig {
 
     @Bean

--- a/src/test/kotlin/com/tyro/oss/rabbit_amazon_bridge/config/ExtraPropertiesFileIT.kt
+++ b/src/test/kotlin/com/tyro/oss/rabbit_amazon_bridge/config/ExtraPropertiesFileIT.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright [2018] Tyro Payments Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tyro.oss.rabbit_amazon_bridge.monitoring
+
+import com.google.gson.Gson
+import com.google.gson.JsonObject
+import com.tyro.oss.rabbit_amazon_bridge.RabbitAmazonBridgeSpringBootTest
+import org.apache.http.impl.client.HttpClientBuilder
+import org.assertj.core.api.Assertions
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.context.junit4.SpringRunner
+
+@RunWith(SpringRunner::class)
+@RabbitAmazonBridgeSpringBootTest
+@AutoConfigureMockMvc
+@DirtiesContext
+abstract class HealthStatusITBase {
+    @Value("\${server.port}")
+    lateinit var port: String
+
+    protected fun getHealthStatus(port: String): ResponseEntity<String> =
+            createRestTemplate()
+                    .getForEntity("http://localhost:$port/rabbit-amazon-bridge/health", String::class.java)
+
+    protected fun createRestTemplate(): TestRestTemplate {
+        val closeableHttpClient = HttpClientBuilder.create().build()
+
+        val template = TestRestTemplate()
+        val httpRequestFactory = template.restTemplate.requestFactory as HttpComponentsClientHttpRequestFactory
+        httpRequestFactory.httpClient = closeableHttpClient
+        return template
+    }
+}
+
+class HealthStatusDefaultIT : HealthStatusITBase() {
+
+    @Test
+    fun `should return flat response`() {
+        val entity = getHealthStatus(port)
+        Assertions.assertThat(entity.statusCode).isEqualTo(HttpStatus.OK)
+
+        val json = Gson().fromJson<JsonObject>(entity.body, JsonObject::class.java)
+        val rabbitHealth = json.get("rabbit").asJsonObject
+        Assertions.assertThat(rabbitHealth.get("status").asString).isEqualTo("UP")
+    }
+
+}
+
+@TestPropertySource(properties = ["flat.healthcheck.response.format=true"])
+class HealthStatusFlatteningEnabledIT : HealthStatusITBase() {
+
+    @Test
+    fun `should return flat response`() {
+        val entity = getHealthStatus(port)
+        Assertions.assertThat(entity.statusCode).isEqualTo(HttpStatus.OK)
+
+        val json = Gson().fromJson<JsonObject>(entity.body, JsonObject::class.java)
+        val rabbitHealth = json.get("rabbit").asJsonObject
+        Assertions.assertThat(rabbitHealth.get("status").asString).isEqualTo("UP")
+    }
+
+}
+
+@TestPropertySource(properties = ["flat.healthcheck.response.format=false"])
+class HealthStatusFlatteningDisabledIT : HealthStatusITBase() {
+
+    @Test
+    fun `should return flat response`() {
+        val entity = getHealthStatus(port)
+        Assertions.assertThat(entity.statusCode).isEqualTo(HttpStatus.OK)
+
+        val json = Gson().fromJson<JsonObject>(entity.body, JsonObject::class.java)
+        val details = json.get("details").asJsonObject
+        val rabbitHealth = details.get("rabbit").asJsonObject
+        val statusHealth = rabbitHealth.get("status").asJsonObject
+
+        Assertions.assertThat(statusHealth.get("code").asString).isEqualTo("UP")
+    }
+
+}

--- a/src/test/resources/application-docker-integration-test.properties
+++ b/src/test/resources/application-docker-integration-test.properties
@@ -9,3 +9,6 @@ bridge.config.location=classpath:test-bridge-config.json
 
 aws.sqs.endpoint.url=http://localsqs:9324
 aws.sqs.aws.region=elasticmq
+
+aws.credentials.secretKey=x
+aws.credentials.accessKey=x

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -25,3 +25,6 @@ bridge.config.location=classpath:test-bridge-config.json
 
 aws.sqs.endpoint.url=http://localhost:9324
 aws.sqs.aws.region=localhost
+
+aws.credentials.secretKey=x
+aws.credentials.accessKey=x

--- a/src/test/resources/extra-properties.properties
+++ b/src/test/resources/extra-properties.properties
@@ -1,0 +1,17 @@
+#
+# Copyright [2018] Tyro Payments Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+expected.test.property=The customer property file was configured


### PR DESCRIPTION
The property extra.properties.file can be set to provide an extra spring resource property file to be included in the application. This may be useful if you have some properties being managed by puppet with a file name that can't  be managed by spring profiles.

This resolves #9 