### PR TITLE
Extracting a default.incoming.message.id.key

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -119,6 +119,17 @@ aws.proxy.host=<proxy-host>
 aws.proxy.port=<proxy-port>
 ```
 
+#### Default message id key for incoming messages
+When messages come in from AWS on SQS or SNS they contain a 'messageId' that may be useful to some as a correlation id. 
+This messageId can be added to the messages prior to publishing the to payload to rabbit. 
+
+```properties
+default.incoming.message.id.key=globalMessageId
+```
+
+**Default**: uniqueReference
+
+If you do not want this setting you can set it to `#{null}`
 
 ### Additional useful Spring Properties
 Rabbit amazon bridge is based on spring boot so you can use almost any property it supports using it's relaxed binding.

--- a/README.MD
+++ b/README.MD
@@ -103,14 +103,6 @@ We mostly for shifting (which we use to strip out sensitive fields) and/or field
 ### Customised properties
 We've added a few custom properties
 
-#### Change your SQS endpoint url
-This is used for working with elasticmq for local testing.  
-
-```properties  
-aws.sqs.endpoint.url=http://localhost:9324
-aws.sqs.aws.region=localhost
-```
-
 #### Proxied comms to AWS
 This may be useful for organisations who want all traffic between their on-premise artefacts and amazon to go through a proxy.
 
@@ -119,17 +111,26 @@ aws.proxy.host=<proxy-host>
 aws.proxy.port=<proxy-port>
 ```
 
+This is disabled by default
+
 #### Default message id key for incoming messages
 When messages come in from AWS on SQS or SNS they contain a 'messageId' that may be useful to some as a correlation id. 
 This messageId can be added to the messages prior to publishing the to payload to rabbit. 
+The format of this field is <queue-name>/messageId
 
 ```properties
 default.incoming.message.id.key=globalMessageId
 ```
 
-**Default**: uniqueReference
+**Default**: null
 
-If you do not want this setting you can set it to `#{null}`
+#### Change your SQS endpoint url
+This is used for working with elasticmq for local testing.  
+
+```properties  
+aws.sqs.endpoint.url=http://localhost:9324
+aws.sqs.aws.region=localhost
+```
 
 ### Additional useful Spring Properties
 Rabbit amazon bridge is based on spring boot so you can use almost any property it supports using it's relaxed binding.

--- a/src/main/kotlin/com/tyro/oss/rabbit_amazon_bridge/poller/SQSDispatcher.kt
+++ b/src/main/kotlin/com/tyro/oss/rabbit_amazon_bridge/poller/SQSDispatcher.kt
@@ -19,7 +19,7 @@ package com.tyro.oss.rabbit_amazon_bridge.poller
 import com.amazonaws.services.sqs.AmazonSQSAsync
 import org.slf4j.LoggerFactory
 
-class SQSDispatcher(private val amazonSQS: AmazonSQSAsync, val sqsReceiver: SQSReceiver, val rabbitSender: RabbitSender, val queueUrl: String, val queueName: String) : Runnable {
+class SQSDispatcher(private val amazonSQS: AmazonSQSAsync, val sqsReceiver: SQSReceiver, val rabbitSender: RabbitSender, val queueUrl: String, val queueName: String, val messageIdKey: String?) : Runnable {
 
     override fun run() {
 
@@ -29,7 +29,7 @@ class SQSDispatcher(private val amazonSQS: AmazonSQSAsync, val sqsReceiver: SQSR
             val receiptHandle = it.receiptHandle
 
             try {
-                rabbitSender.send(messageConverter.convert(it, queueName))
+                rabbitSender.send(messageConverter.convert(it, queueName, messageIdKey))
                 amazonSQS.deleteMessageAsync(queueUrl, receiptHandle)
             } catch (e: Exception) {
                 amazonSQS.changeMessageVisibilityAsync(queueUrl, receiptHandle, 0)

--- a/src/main/kotlin/com/tyro/oss/rabbit_amazon_bridge/poller/SQSMessageConverter.kt
+++ b/src/main/kotlin/com/tyro/oss/rabbit_amazon_bridge/poller/SQSMessageConverter.kt
@@ -26,7 +26,6 @@ class SQSMessageConverter {
 
     fun convert(message: IncomingAwsMessage, prefix: String, messageIdKey: String?): String {
 
-
         val incomingMessageId = message.messageId
         val bodyJsonObject = message.body.asJson()
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -61,4 +61,4 @@ cloud.aws.region.auto=false
 cloud.aws.credentials.accessKey=${aws.credentials.accessKey}
 cloud.aws.credentials.secretKey=${aws.credentials.secretKey}
 
-default.incoming.message.id.key=uniqueReference
+default.incoming.message.id.key=#{null}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -60,3 +60,5 @@ cloud.aws.stack.auto=false
 cloud.aws.region.auto=false
 cloud.aws.credentials.accessKey=${aws.credentials.accessKey}
 cloud.aws.credentials.secretKey=${aws.credentials.secretKey}
+
+default.incoming.message.id.key=uniqueReference

--- a/src/test/kotlin/com/tyro/oss/rabbit_amazon_bridge/poller/SQSPollersConfigurerTest.kt
+++ b/src/test/kotlin/com/tyro/oss/rabbit_amazon_bridge/poller/SQSPollersConfigurerTest.kt
@@ -24,6 +24,7 @@ import com.nhaarman.mockito_kotlin.verify
 import com.nhaarman.mockito_kotlin.whenever
 import com.tyro.oss.rabbit_amazon_bridge.generator.RabbitCreationService
 import com.tyro.oss.rabbit_amazon_bridge.generator.fromSQSToRabbitInstance
+import com.tyro.oss.randomdata.RandomString.randomString
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -55,6 +56,7 @@ class SQSPollersConfigurerTest{
                 fromSQSToRabbitInstance(),
                 fromSQSToRabbitInstance()
         )
+        val messageIdKey = randomString()
 
         bridgesFromSQS.forEach {
             whenever(amazonSQS.getQueueUrl(it.from.sqs!!.name)).thenReturn(
@@ -64,7 +66,7 @@ class SQSPollersConfigurerTest{
             )
         }
 
-        val config = SQSPollersConfigurer(amazonSQS, bridgesFromSQS, rabbitTemplate, rabbitCreationService)
+        val config = SQSPollersConfigurer(amazonSQS, bridgesFromSQS, rabbitTemplate, rabbitCreationService, messageIdKey)
 
         config.configureTasks(taskRegistrar)
 
@@ -83,6 +85,7 @@ class SQSPollersConfigurerTest{
             assertThat(dispatcher.rabbitSender.routingKey).isEqualTo(bridge.to.rabbit!!.routingKey)
             assertThat(dispatcher.queueUrl).isEqualTo("https://thing.com/${bridge.from.sqs!!.name}")
             assertThat(dispatcher.sqsReceiver.queueUrl).isEqualTo("https://thing.com/${bridge.from.sqs!!.name}")
+            assertThat(dispatcher.messageIdKey).isEqualTo(messageIdKey)
         }
 
     }


### PR DESCRIPTION
This allows the setting uniqueReference to be overridden, or turned off.

I think having a global default should be good enough at this stage. If we want to have different values per queue we can look at adding to the bridge configuration or adding a new type of transformation. 

This should resolve #12 