### PR TITLE
Improve dead-lettering support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -211,6 +211,10 @@
             <version>${spring-cloud.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.springframework.retry</groupId>
+            <artifactId>spring-retry</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.bazaarvoice.jolt</groupId>
             <artifactId>jolt-core</artifactId>
             <version>${latest.jolt.version}</version>

--- a/src/main/kotlin/com/tyro/oss/rabbit_amazon_bridge/config/MainConfig.kt
+++ b/src/main/kotlin/com/tyro/oss/rabbit_amazon_bridge/config/MainConfig.kt
@@ -28,7 +28,7 @@ import org.springframework.context.annotation.*
 import org.springframework.jmx.support.RegistrationPolicy
 
 @Configuration
-@Import(TaskSchedulerConfig::class, RestConfig::class, RabbitEndPointConfigurer::class, SQSPollersConfigurer::class)
+@Import(TaskSchedulerConfig::class, RestConfig::class, RabbitEndPointConfigurer::class, RabbitRetryConfig::class, SQSPollersConfigurer::class)
 @ComponentScan(value = ["com.tyro.oss.rabbit_amazon_bridge"], excludeFilters = [ComponentScan.Filter(Configuration::class)])
 @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
 @PropertySource(value = ["\${extra.properties.file}"], ignoreResourceNotFound = true)

--- a/src/main/kotlin/com/tyro/oss/rabbit_amazon_bridge/config/RabbitRetryConfig.kt
+++ b/src/main/kotlin/com/tyro/oss/rabbit_amazon_bridge/config/RabbitRetryConfig.kt
@@ -1,0 +1,43 @@
+package com.tyro.oss.rabbit_amazon_bridge.config
+
+import com.amazonaws.SdkBaseException
+import org.springframework.amqp.AmqpRejectAndDontRequeueException
+import org.springframework.amqp.rabbit.config.RetryInterceptorBuilder
+import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory
+import org.springframework.amqp.rabbit.connection.ConnectionFactory
+import org.springframework.amqp.rabbit.retry.RejectAndDontRequeueRecoverer
+import org.springframework.boot.autoconfigure.amqp.RabbitProperties
+import org.springframework.boot.autoconfigure.amqp.SimpleRabbitListenerContainerFactoryConfigurer
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.retry.policy.SimpleRetryPolicy
+
+@Configuration
+class RabbitRetryConfig {
+
+    @Bean(name = ["rabbitListenerContainerFactory"])
+    fun simpleRabbitListenerContainerFactory(
+            configurer: SimpleRabbitListenerContainerFactoryConfigurer,
+            connectionFactory: ConnectionFactory,
+            properties: RabbitProperties): SimpleRabbitListenerContainerFactory {
+        val factory = SimpleRabbitListenerContainerFactory()
+        configurer.configure(factory, connectionFactory)
+
+        val retryConfig = properties.listener.simple.retry
+        if (retryConfig.isEnabled) {
+            val simpleRetryPolicy = SimpleRetryPolicy(retryConfig.maxAttempts, mapOf<Class<out Throwable>, Boolean>(
+                    AmqpRejectAndDontRequeueException::class.java to false,
+                    SdkBaseException::class.java to true
+            ), true)
+            val retryOperationsInterceptor = RetryInterceptorBuilder.stateless()
+                    .retryPolicy(simpleRetryPolicy)
+                    .backOffOptions(retryConfig.initialInterval.toMillis(), retryConfig.multiplier, retryConfig.maxInterval.toMillis())
+                    .recoverer(RejectAndDontRequeueRecoverer())
+                    .build()
+
+            factory.setAdviceChain(retryOperationsInterceptor)
+        }
+
+        return factory
+    }
+}

--- a/src/main/kotlin/com/tyro/oss/rabbit_amazon_bridge/forwarder/ForwardingMessageListeners.kt
+++ b/src/main/kotlin/com/tyro/oss/rabbit_amazon_bridge/forwarder/ForwardingMessageListeners.kt
@@ -16,6 +16,7 @@
 
 package com.tyro.oss.rabbit_amazon_bridge.forwarder
 
+import com.amazonaws.SdkBaseException
 import com.tyro.oss.rabbit_amazon_bridge.messagetransformer.MessageTransformer
 import org.slf4j.LoggerFactory
 import org.springframework.amqp.AmqpRejectAndDontRequeueException
@@ -52,7 +53,7 @@ class SqsForwardingMessageListener(
     }
 }
 
-class DeadletteringMessageListener(val messageListener: MessageListener) : MessageListener {
+class DeadletteringMessageListener(val messageListener: MessageListener, val shouldRetry: Boolean = false) : MessageListener {
 
     private val LOG = LoggerFactory.getLogger(DeadletteringMessageListener::class.java)
 
@@ -60,6 +61,13 @@ class DeadletteringMessageListener(val messageListener: MessageListener) : Messa
         try {
             LOG.info("Message received on ${rabbitMessage.messageProperties.receivedExchange} / ${rabbitMessage.messageProperties.consumerQueue}")
             messageListener.onMessage(rabbitMessage)
+        } catch (exception: SdkBaseException) {
+            if (shouldRetry) {
+                LOG.warn("A retryable error occurred.", exception)
+                throw exception
+            } else {
+                throw AmqpRejectAndDontRequeueException(exception)
+            }
         } catch (exception: Exception) {
             throw AmqpRejectAndDontRequeueException(exception)
         }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -51,6 +51,13 @@ spring.rabbitmq.listener.simple.default-requeue-rejected=true
 spring.rabbitmq.listener.simple.concurrency=5
 spring.rabbitmq.listener.simple.max-concurrency=10
 
+# Whether publishing retries are enabled.
+spring.rabbitmq.listener.simple.retry.enabled=true
+spring.rabbitmq.listener.simple.retry.initial-interval=1000ms
+spring.rabbitmq.listener.simple.retry.max-attempts=30000
+spring.rabbitmq.listener.simple.retry.max-interval=60000ms
+spring.rabbitmq.listener.simple.retry.multiplier=2
+
 spring.rabbitmq.connection-timeout=2s
 spring.rabbitmq.requested-heartbeat=30s
 spring.rabbitmq.template.receive-timeout=5s

--- a/src/test/kotlin/com/tyro/oss/rabbit_amazon_bridge/config/RabbitForwardingRetryIT.kt
+++ b/src/test/kotlin/com/tyro/oss/rabbit_amazon_bridge/config/RabbitForwardingRetryIT.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright [2018] Tyro Payments Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tyro.oss.rabbit_amazon_bridge.forwarder
+
+import com.tyro.oss.rabbit_amazon_bridge.RabbitAmazonBridgeSpringBootTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.retry.interceptor.RetryOperationsInterceptor
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.context.junit4.SpringRunner
+
+@RunWith(SpringRunner::class)
+@RabbitAmazonBridgeSpringBootTest
+@AutoConfigureMockMvc
+@DirtiesContext
+class RabbitForwardingRetryDefaultIT {
+
+    @Autowired
+    lateinit var rabbitListenerContainerFactory: SimpleRabbitListenerContainerFactory
+
+    @Test
+    fun `should have a retry operations advice configured by default`() {
+        assertThat(rabbitListenerContainerFactory.adviceChain[0]).isInstanceOf(RetryOperationsInterceptor::class.java)
+    }
+
+}
+
+@RunWith(SpringRunner::class)
+@RabbitAmazonBridgeSpringBootTest
+@AutoConfigureMockMvc
+@DirtiesContext
+@TestPropertySource(properties = ["spring.rabbitmq.listener.simple.retry.enabled=false"])
+class RabbitForwardingRetryDisabledIT {
+
+    @Autowired
+    lateinit var rabbitListenerContainerFactory: SimpleRabbitListenerContainerFactory
+
+    @Test
+    fun `should not have a retry operations advice configured when retry is disabled`() {
+        assertThat(rabbitListenerContainerFactory.adviceChain).isNullOrEmpty()
+    }
+
+}

--- a/src/test/kotlin/com/tyro/oss/rabbit_amazon_bridge/generator/BridgeGeneratorTest.kt
+++ b/src/test/kotlin/com/tyro/oss/rabbit_amazon_bridge/generator/BridgeGeneratorTest.kt
@@ -25,6 +25,7 @@ import com.tyro.oss.rabbit_amazon_bridge.forwarder.DeadletteringMessageListener
 import com.tyro.oss.rabbit_amazon_bridge.forwarder.SnsForwardingMessageListener
 import com.tyro.oss.rabbit_amazon_bridge.forwarder.SqsForwardingMessageListener
 import com.tyro.oss.rabbit_amazon_bridge.messagetransformer.JoltMessageTransformer
+import com.tyro.oss.randomdata.RandomBoolean.randomBoolean
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -48,6 +49,8 @@ class BridgeGeneratorTest {
 
     private lateinit var bridgeGenerator: BridgeGenerator
 
+    private val shouldRetry = randomBoolean()
+
     private val gson = Gson()
 
     companion object {
@@ -68,7 +71,8 @@ class BridgeGeneratorTest {
                 deadLetteringrabbitCreationService,
                 queueMessagingTemplate,
                 topicNotificationMessagingTemplate,
-                gson
+                gson,
+                shouldRetry
         )
     }
 
@@ -97,6 +101,7 @@ class BridgeGeneratorTest {
         val deadletteringMessageListener = endPoint.messageListener as DeadletteringMessageListener
         assertThat(endPoint.id).isEqualTo("org.springframework.amqp.rabbit.RabbitListenerEndpointContainer#$index")
         assertThat(endPoint.queueNames).isEqualTo(listOf(fromRabbit.queueName))
+        assertThat(deadletteringMessageListener.shouldRetry).isEqualTo(shouldRetry)
         val snsMessageListener = deadletteringMessageListener.messageListener as SnsForwardingMessageListener
         assertThat(snsMessageListener.topicName).isEqualTo(bridge.to.sns?.name)
         assertThat(snsMessageListener.topicNotificationMessagingTemplate).isEqualTo(topicNotificationMessagingTemplate)
@@ -127,6 +132,7 @@ class BridgeGeneratorTest {
         val deadletteringMessageListener = endPoint.messageListener as DeadletteringMessageListener
         assertThat(endPoint.id).isEqualTo("org.springframework.amqp.rabbit.RabbitListenerEndpointContainer#$index")
         assertThat(endPoint.queueNames).isEqualTo(listOf(fromRabbit.queueName))
+        assertThat(deadletteringMessageListener.shouldRetry).isEqualTo(shouldRetry)
         val sqsMessageListener = deadletteringMessageListener.messageListener as SqsForwardingMessageListener
         assertThat(sqsMessageListener.queueName).isEqualTo(bridge.to.sqs?.name)
         assertThat(sqsMessageListener.queueMessagingTemplate).isEqualTo(queueMessagingTemplate)


### PR DESCRIPTION
- This fixes #33
- Automatically retry on the forwarders for any AmazonSDK exception as they are most likely recoverable
- Deadletter on any other exception
- Turn on retries by default

Co-authored-by: mselvaku <mselvakumar@tyro.com>