### PR TITLE
Pinned tomcat-embed-core to 9.0.19 to fix CVE-2019-0232 and CVE-2019-…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -322,6 +322,13 @@
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-kotlin</artifactId>
         </dependency>
+        <!-- Pinned version to prevent CVE-2019-0232 and CVE-2019-0199.
+        Kepe this pinned until spring-boot-starter-tomcat brings in a non-vulnerable version (9.0.19+)-->
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-core</artifactId>
+            <version>9.0.19</version>
+        </dependency>
 
         <!-- Test dependencies -->
         <dependency>


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2019-0232
https://nvd.nist.gov/vuln/detail/CVE-2019-0199

spring-boot-starter-tomcat:2.1.4.RELEASE (latest) is still on tomcat-embed-core:9.0.17