### PR TITLE
Set scm.tag to HEAD for development

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <connection>scm:git:https://github.com/tyro/rabbit-amazon-bridge.git</connection>
         <developerConnection>scm:git:https://github.com/tyro/rabbit-amazon-bridge.git</developerConnection>
         <url>https://github.com/tyro/rabbit-amazon-bridge</url>
-        <tag>0.14.1</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <parent>


### PR DESCRIPTION
The scm tag should be 'HEAD' for development:
https://maven.apache.org/ref/3.5.0/maven-model/maven.html#class_scm